### PR TITLE
Execute user tasks according to system tag

### DIFF
--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -12,6 +12,7 @@
     - "{{ base_users | default([]) }}"
   loop_control:
     loop_var: base_user
+  when: system_type in base_user.system_types
 
 - name: Secure ssh server config
   include_tasks: sshd.yml


### PR DESCRIPTION
Allow user tasks to be only run if a user has a according system_types
entry for a playbook.